### PR TITLE
fix issue with losing newlines in created script

### DIFF
--- a/Tools/Create-StandaloneScript.ps1
+++ b/Tools/Create-StandaloneScript.ps1
@@ -192,7 +192,7 @@ Begin {
                     if (-not($ImportModuleCommands.ContainsValue($Count))) {
                         foreach ($ModuleName In $Module) {
                             if (-not(($_.Contains("Requires")) -and  ($_.Contains($ModuleName)))) {
-                                $StringBuilder.Append($_) | Out-Null
+                                $StringBuilder.AppendLine($_) | Out-Null
                             }
                         }
                     } else {


### PR DESCRIPTION
Fixes an issue where the created script loses the newlines from the original. Weirdly I only see this issue on some devices and not others - however, `.AppendLines()` gives correct (or at least executable) output every time. 

It may be the case that line 189 should be ```$Script.ToString().Split("`r`n") |```  not ```$Script.ToString().Split("`n") | ``` to match (commented out) line 126 ... but this pull request includes the change I've made that makes the script work for me.